### PR TITLE
Add more option to FoldGutterConfig

### DIFF
--- a/src/fold.ts
+++ b/src/fold.ts
@@ -197,17 +197,35 @@ const foldWidget = Decoration.replace({widget: new class extends WidgetType {
 }})
 
 interface FoldGutterConfig {
-  /// Text used to indicate that a given line can be folded. Defaults
-  /// to `"⌄"`.
-  openText?: string
-  /// Text used to indicate that a given line is folded. Defaults to
-  /// `"›"`.
-  closedText?: string
+  /// A function that creates the DOM element used to indicate a
+  /// given line can be folded. 
+  /// When not given, the `openText` option will be used instead.
+  openDOM?: (() => HTMLElement) | null,
+  /// A function that creates the DOM element used to indicate a
+  /// given line is folded. 
+  /// When not given, the `closedText` option will be used instead.
+  closedDOM?: (() => HTMLElement) | null,
+  /// Text used to indicate that a given line can be folded. 
+  /// Defaults to `"⌄"`.
+  openText?: string,
+  /// Text used to indicate that a given line is folded. 
+  /// Defaults to `"›"`.
+  closedText?: string,
+  /// Text used to provide extra open information. 
+  /// Defaults to `"Fold line"`.
+  openTitle?: string | null,
+  /// Text used to provide extra closed information. 
+  /// Defaults to `"Unfold line"`.
+  closedTitle?: string | null,
 }
 
 const foldGutterDefaults: Required<FoldGutterConfig> = {
   openText: "⌄",
-  closedText: "›"
+  closedText: "›",
+  openDOM: null,
+  closedDOM: null,
+  openTitle: "Fold line",
+  closedTitle: "Unfold line"
 }
 
 class FoldMarker extends GutterMarker {
@@ -217,9 +235,13 @@ class FoldMarker extends GutterMarker {
   eq(other: FoldMarker) { return this.config == other.config && this.open == other.open }
 
   toDOM(view: EditorView) {
+    if (this.open && this.config.openDOM) return this.config.openDOM()
+    else if (!this.open && this.config.closedDOM) return this.config.closedDOM()
+
     let span = document.createElement("span")
     span.textContent = this.open ? this.config.openText : this.config.closedText
-    span.title = view.state.phrase(this.open ? "Fold line" : "Unfold line")
+    if (this.open && this.config.openTitle) span.title = view.state.phrase(this.config.openTitle)
+    else if (!this.open && this.config.closedTitle) span.title = view.state.phrase(this.config.closedTitle)
     return span
   }
 }

--- a/src/fold.ts
+++ b/src/fold.ts
@@ -198,34 +198,21 @@ const foldWidget = Decoration.replace({widget: new class extends WidgetType {
 
 interface FoldGutterConfig {
   /// A function that creates the DOM element used to indicate a
-  /// given line can be folded. 
+  /// given line is folded or can be folded. 
   /// When not given, the `openText` option will be used instead.
-  openDOM?: (() => HTMLElement) | null,
-  /// A function that creates the DOM element used to indicate a
-  /// given line is folded. 
-  /// When not given, the `closedText` option will be used instead.
-  closedDOM?: (() => HTMLElement) | null,
+  markerDOM?: ((open: boolean) => HTMLElement) | null,
   /// Text used to indicate that a given line can be folded. 
   /// Defaults to `"⌄"`.
   openText?: string,
   /// Text used to indicate that a given line is folded. 
   /// Defaults to `"›"`.
   closedText?: string,
-  /// Text used to provide extra open information. 
-  /// Defaults to `"Fold line"`.
-  openTitle?: string | null,
-  /// Text used to provide extra closed information. 
-  /// Defaults to `"Unfold line"`.
-  closedTitle?: string | null,
 }
 
 const foldGutterDefaults: Required<FoldGutterConfig> = {
   openText: "⌄",
   closedText: "›",
-  openDOM: null,
-  closedDOM: null,
-  openTitle: "Fold line",
-  closedTitle: "Unfold line"
+  markerDOM: null,
 }
 
 class FoldMarker extends GutterMarker {
@@ -235,13 +222,11 @@ class FoldMarker extends GutterMarker {
   eq(other: FoldMarker) { return this.config == other.config && this.open == other.open }
 
   toDOM(view: EditorView) {
-    if (this.open && this.config.openDOM) return this.config.openDOM()
-    else if (!this.open && this.config.closedDOM) return this.config.closedDOM()
+    if (this.config.markerDOM) return this.config.markerDOM(this.open)
 
     let span = document.createElement("span")
     span.textContent = this.open ? this.config.openText : this.config.closedText
-    if (this.open && this.config.openTitle) span.title = view.state.phrase(this.config.openTitle)
-    else if (!this.open && this.config.closedTitle) span.title = view.state.phrase(this.config.closedTitle)
+    span.title = view.state.phrase(this.open ? "Fold line" : "Unfold line")
     return span
   }
 }


### PR DESCRIPTION
Hi,

I am working on styling the fold gutter of my editor and I would like:
1. use HTMLElement (e.g. SVG) instead of the "openText/closedText"
2. get rid of gutter marker titles

To do so, I would adjust the FoldGutterConfig so it accepts:
1. Functions that return a HTMLElement (as it is done for FoldConfig)
2. String to customize title text (could also be null)

Feel free to accept this PR if it make sense to you.