### PR TITLE
Add EditorView as an arugment to the placeholderDOM function

### DIFF
--- a/src/fold.ts
+++ b/src/fold.ts
@@ -152,7 +152,7 @@ interface FoldConfig {
   /// A function that creates the DOM element used to indicate the
   /// position of folded code. When not given, the `placeholderText`
   /// option will be used instead.
-  placeholderDOM?: (() => HTMLElement) | null,
+  placeholderDOM?: ((view: EditorView) => HTMLElement) | null,
   /// Text to use as placeholder for folded text. Defaults to `"…"`.
   /// Will be styled with the `"cm-foldPlaceholder"` class.
   placeholderText?: string
@@ -179,7 +179,7 @@ const foldWidget = Decoration.replace({widget: new class extends WidgetType {
 
   toDOM(view: EditorView) {
     let {state} = view, conf = state.facet(foldConfig)
-    if (conf.placeholderDOM) return conf.placeholderDOM()
+    if (conf.placeholderDOM) return conf.placeholderDOM(view)
     let element = document.createElement("span")
     element.textContent = conf.placeholderText
     element.setAttribute("aria-label", state.phrase("folded code"))


### PR DESCRIPTION
Hey,

I'm currently writing something that requires some additional customizability when it comes to the foldWidget, which in my case should be easily achievable by providing a custom placeholderDOM function. The problem however, is that I also need access to the EditorView, similar to how the default implementation does for unfolding the range and so on.